### PR TITLE
説明書きの変更

### DIFF
--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -51,7 +51,7 @@ Host paus
       <h3>3. Add remote repository</h3>
 
       <pre>
-$ git remote add paus git@paus:yourname/repository</pre>
+$ git remote add paus git@paus:repository</pre>
 
       <h3>4. <code>git push</code> and deploy!</h3>
 


### PR DESCRIPTION
## WHY, WHAT

https://github.com/wantedly/paus-gitreceive/blob/master/files/receiver#L20
ここでpushしたユーザー名が分かるので、

```
git remote add paus git@paus:username/repository
```

は冗長な気がします。

```
git remote add paus git@paus:repository
```

こう書けるように
https://github.com/wantedly/paus-gitreceive/pull/2
こちらで修正を加えています。

それに合わせて説明書きを変更しました。
