### PR TITLE
Install glibc package

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,11 +2,18 @@ FROM alpine:3.3
 MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 
 ENV DOCKER_COMPOSE_VERSION 1.6.0
+ENV GLIBC_VERSION 2.23-r1
 ENV PAUS_RELEASE_MODE 1
 
-RUN apk --update add docker && \
+RUN apk --update add ca-certificates docker && \
     wget -O /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-Linux-x86_64 && \
     chmod +x /usr/local/bin/docker-compose && \
+    wget -O glibc.apk https://github.com/andyshinn/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk && \
+    wget -O glibc-bin.apk https://github.com/andyshinn/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk && \
+    apk add --allow-untrusted glibc.apk glibc-bin.apk && \
+    /usr/glibc-compat/sbin/ldconfig /usr/glibc-compat/lib && \
+    rm glibc.apk glibc-bin.apk && \
+    apk del --purge ca-certificates && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /app


### PR DESCRIPTION
## WHY

Executing `docker-compose` fails with the below error in Docker container:

``` bash
/app # /usr/local/bin/docker-compose
/bin/sh: /usr/local/bin/docker-compose: not found
```
## WHAT

Install glibc package.

``` bash
/app # /usr/local/bin/docker-compose
Define and run multi-container applications with Docker.

Usage:
  docker-compose [-f=<arg>...] [options] [COMMAND] [ARGS...]
  docker-compose -h|--help

Options:
  -f, --file FILE           Specify an alternate compose file (default: docker-compose.yml)
  -p, --project-name NAME   Specify an alternate project name (default: directory name)
  --verbose                 Show more output
  -v, --version             Print version and exit

Commands:
  build              Build or rebuild services
  config             Validate and view the compose file
  create             Create services
  down               Stop and remove containers, networks, images, and volumes
  events             Receive real time events from containers
  help               Get help on a command
  kill               Kill containers
  logs               View output from containers
  pause              Pause services
  port               Print the public port for a port binding
  ps                 List containers
  pull               Pulls service images
  restart            Restart services
  rm                 Remove stopped containers
  run                Run a one-off command
  scale              Set number of containers for a service
  start              Start services
  stop               Stop services
  unpause            Unpause services
  up                 Create and start containers
  version            Show the Docker-Compose version information
```
