### PR TITLE
Create /paus etcd directory if not exist at first

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -36,6 +36,12 @@ func (c *Etcd) Get(key string) (string, error) {
 	return resp.Node.Value, nil
 }
 
+func (c *Etcd) HasKey(key string) bool {
+	_, err := c.keysAPI.Get(context.Background(), key, &client.GetOptions{})
+
+	return err == nil
+}
+
 func (c *Etcd) List(key string, recursive bool) ([]string, error) {
 	result := []string{}
 
@@ -66,6 +72,12 @@ func (c *Etcd) ListWithValues(key string, recursive bool) (*map[string]string, e
 	}
 
 	return &result, nil
+}
+
+func (c *Etcd) Mkdir(key string) error {
+	_, err := c.keysAPI.Set(context.Background(), key, "", &client.SetOptions{Dir: true})
+
+	return err
 }
 
 func (c *Etcd) Set(key, value string) error {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if !etcd.HasKey("/paus") {
+		if err = etcd.Mkdir("/paus"); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	r := gin.Default()
 	r.LoadHTMLGlob("templates/*")
 


### PR DESCRIPTION
## WHY

After first launch with no application, `/paus` etcd directory does not exist and it causes error.

```
error: 100: Key not found (/paus) [34]
```
## WHAT

Create `/paus` directory at first
