### PR TITLE
Show variable pairs in monospace font

### DIFF
--- a/templates/app.tmpl
+++ b/templates/app.tmpl
@@ -46,8 +46,8 @@
             <tbody>
               {{ range $key, $value := .buildArgs }}
               <tr>
-                <td>{{ $key }}</td>
-                <td> {{ $value }}</td>
+                <td><tt>{{ $key }}</tt></td>
+                <td><tt>{{ $value }}</tt></td>
               </tr>
               {{ end }}
             </tbody>
@@ -88,8 +88,8 @@
             <tbody>
               {{ range $key, $value := .envs }}
               <tr>
-                <td>{{ $key }}</td>
-                <td> {{ $value }}</td>
+                <td><tt>{{ $key }}</tt></td>
+                <td><tt>{{ $value }}</tt></td>
               </tr>
               {{ end }}
             </tbody>


### PR DESCRIPTION
## WHAT

Show build-time variables and environment variables in monospace font using `<tt>`.
