### PR TITLE
Prepare local test enviornment

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,10 +10,11 @@ const (
 )
 
 type Config struct {
-	BaseDomain   string `envconfig:"base_domain"   required:"true"`
-	EtcdEndpoint string `envconfig:"etcd_endpoint" default:"http://localhost:2379"`
-	ReleaseMode  bool   `envconfig:"release_mode"  default:"false"`
-	URIScheme    string `envconfig:"uri_scheme"    default:"http"`
+	BaseDomain    string `envconfig:"base_domain"   required:"true"`
+	EtcdEndpoint  string `envconfig:"etcd_endpoint" default:"http://localhost:2379"`
+	ReleaseMode   bool   `envconfig:"release_mode"  default:"false"`
+	SkipKeyUpload bool   `envconfig:"skip_key_upload" default:"false"`
+	URIScheme     string `envconfig:"uri_scheme"    default:"http"`
 }
 
 func LoadConfig() (*Config, error) {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ func initialize(config *Config, etcd *Etcd) error {
 }
 
 func main() {
+	var out string
+
 	config, err := LoadConfig()
 
 	if err != nil {
@@ -306,19 +308,23 @@ func main() {
 			return
 		}
 
-		out, err := UploadPublicKey(username, pubKey)
+		if !config.SkipKeyUpload {
+			out, err = UploadPublicKey(username, pubKey)
 
-		if err != nil {
-			errors.Fprint(os.Stderr, err)
+			if err != nil {
+				errors.Fprint(os.Stderr, err)
 
-			c.HTML(http.StatusInternalServerError, "index.tmpl", gin.H{
-				"alert":      true,
-				"error":      true,
-				"message":    "Failed to upload SSH public key.",
-				"baseDomain": config.BaseDomain,
-			})
+				c.HTML(http.StatusInternalServerError, "index.tmpl", gin.H{
+					"alert":      true,
+					"error":      true,
+					"message":    "Failed to upload SSH public key.",
+					"baseDomain": config.BaseDomain,
+				})
 
-			return
+				return
+			}
+		} else {
+			out = "(Skipped)"
 		}
 
 		c.HTML(http.StatusCreated, "index.tmpl", gin.H{


### PR DESCRIPTION
## WHY

Now we have to prepare CoreOS VM to test paus-frontend locally.
## WHAT
- Add Makefile target `make run-etcd` to start etcd standalone container.
- Skip uploading SSH public key w/ paus-gitreceive if `SKIP_KEY_UPLOAD=1` is specified.

to local development:

``` bash
$ make deps
$ make run-etcd
$ make build
$ PAUS_BASE_DOMAIN=pausapp.com SKIP_KEY_UPLOAD=1 bin/paus-frontend
```
