### PR TITLE
Include assets directory in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !main.go
 !glide.lock
 !glide.yaml
+!assets/
 !templates/
 !bin/paus-frontend
 !bin/paus-frontend_linux-amd64

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -19,6 +19,7 @@ RUN apk --update add ca-certificates docker && \
 WORKDIR /app
 
 COPY bin/paus-frontend_linux-amd64 /app/paus-frontend
+COPY assets /app/assets
 COPY templates /app/templates
 
 EXPOSE 8080


### PR DESCRIPTION
## WHAT

paus-frontend Docker container does not include assets, so we cannot fetch any asset.
