### PR TITLE
Update SSH public keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ bin/*
 vendor/
 
 /gin-bin
+
+/.envrc

--- a/templates/_navbar.tmpl
+++ b/templates/_navbar.tmpl
@@ -24,6 +24,8 @@
             <img src="{{ .avater_url }}" height="20" width="20"> {{ .username }} <span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
+            <li><a href="/update-keys">Update SSH public keys</a></li>
+            <li role="separator" class="divider"></li>
             <li><a href="/signout">Sign out</a></li>
           </ul>
         </li>


### PR DESCRIPTION
## WHY

If paus-gitreceive service is restarted, registered SSH public keys are disappeared.
## WHAT

Make it able to update registered SSH public keys from menu.
