### PR TITLE
Configure Healthcheck at deploy

### DIFF
--- a/controller/healthcheck_controller.go
+++ b/controller/healthcheck_controller.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/dtan4/paus-frontend/config"
+	"github.com/dtan4/paus-frontend/model/healthcheck"
+	"github.com/dtan4/paus-frontend/store"
+	"github.com/gin-gonic/gin"
+)
+
+type HealthcheckController struct {
+	*ApplicationController
+}
+
+func NewHealthcheckController(config *config.Config, etcd *store.Etcd) *HealthcheckController {
+	return &HealthcheckController{NewApplicationController(config, etcd)}
+}
+
+func (self *HealthcheckController) Update(c *gin.Context) {
+	username := self.CurrentUser(c)
+
+	if username == "" {
+		c.Redirect(http.StatusFound, "/")
+
+		return
+	}
+
+	appName := c.Param("appName")
+	path := c.PostForm("path")
+
+	interval, err := strconv.Atoi(c.PostForm("interval"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+
+		c.HTML(http.StatusBadRequest, "apps.tmpl", gin.H{
+			"alert":   true,
+			"error":   true,
+			"message": "healthcheck interval is invalid.",
+		})
+
+		return
+	}
+
+	maxTry, err := strconv.Atoi(c.PostForm("maxTry"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+
+		c.HTML(http.StatusBadRequest, "apps.tmpl", gin.H{
+			"alert":   true,
+			"error":   true,
+			"message": "healthcheck maxTry is invalid.",
+		})
+
+		return
+	}
+
+	hc := healthcheck.NewHealthcheck(path, interval, maxTry)
+
+	if err := healthcheck.Update(self.etcd, username, appName, hc); err != nil {
+		c.HTML(http.StatusInternalServerError, "app.tmpl", gin.H{
+			"alert":   true,
+			"error":   true,
+			"message": "Failed to update healthcheck.",
+		})
+
+		return
+	}
+
+	c.Redirect(http.StatusSeeOther, "/apps/"+appName)
+}

--- a/model/app/app.go
+++ b/model/app/app.go
@@ -3,15 +3,14 @@ package app
 import (
 	"strings"
 
+	"github.com/dtan4/paus-frontend/model/healthcheck"
 	"github.com/dtan4/paus-frontend/store"
 )
 
-var (
-	defaultHealthCheck = map[string]string{
-		"path":     "/",
-		"interval": "5",
-		"max-try":  "10",
-	}
+const (
+	defaultHealthcheckPath     = "/"
+	defaultHealthcheckInterval = 5
+	defaultHealthcheckMaxTry   = 10
 )
 
 func Create(etcd *store.Etcd, username, appName string) error {
@@ -27,10 +26,10 @@ func Create(etcd *store.Etcd, username, appName string) error {
 		}
 	}
 
-	for k, v := range defaultHealthCheck {
-		if err := etcd.Set(appKey+"/healthcheck/"+k, v); err != nil {
-			return err
-		}
+	hc := healthcheck.NewHealthcheck(defaultHealthcheckPath, defaultHealthcheckInterval, defaultHealthcheckMaxTry)
+
+	if err := healthcheck.Create(etcd, username, appName, hc); err != nil {
+		return err
 	}
 
 	return nil

--- a/model/app/app.go
+++ b/model/app/app.go
@@ -6,13 +6,29 @@ import (
 	"github.com/dtan4/paus-frontend/store"
 )
 
+var (
+	defaultHealthCheck = map[string]string{
+		"path":     "/",
+		"interval": "5",
+		"max-try":  "10",
+	}
+)
+
 func Create(etcd *store.Etcd, username, appName string) error {
-	if err := etcd.Mkdir("/paus/users/" + username + "/apps/" + appName); err != nil {
+	appKey := "/paus/users/" + username + "/apps/" + appName
+
+	if err := etcd.Mkdir(appKey); err != nil {
 		return err
 	}
 
-	for _, resource := range []string{"build-args", "envs", "deployments"} {
-		if err := etcd.Mkdir("/paus/users/" + username + "/apps/" + appName + "/" + resource); err != nil {
+	for _, resource := range []string{"build-args", "envs", "deployments", "healthcheck"} {
+		if err := etcd.Mkdir(appKey + "/" + resource); err != nil {
+			return err
+		}
+	}
+
+	for k, v := range defaultHealthCheck {
+		if err := etcd.Set(appKey+"/healthcheck/"+k, v); err != nil {
 			return err
 		}
 	}

--- a/model/app/app.go
+++ b/model/app/app.go
@@ -20,7 +20,7 @@ func Create(etcd *store.Etcd, username, appName string) error {
 		return err
 	}
 
-	for _, resource := range []string{"build-args", "envs", "deployments", "healthcheck"} {
+	for _, resource := range []string{"build-args", "envs", "deployments"} {
 		if err := etcd.Mkdir(appKey + "/" + resource); err != nil {
 			return err
 		}

--- a/model/healthcheck/healthcheck.go
+++ b/model/healthcheck/healthcheck.go
@@ -1,0 +1,57 @@
+package healthcheck
+
+import (
+	"encoding/json"
+
+	"github.com/dtan4/paus-frontend/store"
+)
+
+type Healthcheck struct {
+	Path     string
+	Interval int
+	MaxTry   int
+}
+
+func etcdKey(username, appName string) string {
+	return "/paus/users/" + username + "/apps/" + appName + "/healthcheck"
+}
+
+func NewHealthcheck(path string, interval, maxTry int) *Healthcheck {
+	return &Healthcheck{
+		Path:     path,
+		Interval: interval,
+		MaxTry:   maxTry,
+	}
+}
+
+func Create(etcd *store.Etcd, username, appName string, hc *Healthcheck) error {
+	return Update(etcd, username, appName, hc)
+}
+
+func Get(etcd *store.Etcd, username, appName string) (*Healthcheck, error) {
+	val, err := etcd.Get(etcdKey(username, appName))
+	if err != nil {
+		return nil, err
+	}
+
+	var hc Healthcheck
+
+	if err := json.Unmarshal([]byte(val), &hc); err != nil {
+		return nil, err
+	}
+
+	return &hc, nil
+}
+
+func Update(etcd *store.Etcd, username, appName string, hc *Healthcheck) error {
+	b, err := json.Marshal(*hc)
+	if err != nil {
+		return err
+	}
+
+	if err := etcd.Set(etcdKey(username, appName), string(b)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,7 @@ func Run(config *config.Config, etcd *store.Etcd) {
 	appController := controller.NewAppController(config, etcd)
 	argController := controller.NewArgController(config, etcd)
 	envController := controller.NewEnvController(config, etcd)
+	healthcheckController := controller.NewHealthcheckController(config, etcd)
 	sessionController := controller.NewSessionController(config, etcd, oauthConf)
 
 	r.GET("/", rootController.Index)
@@ -57,6 +58,8 @@ func Run(config *config.Config, etcd *store.Etcd) {
 	r.POST("/apps/:appName/envs", envController.New)
 	r.POST("/apps/:appName/envs/delete", envController.Delete) // TODO: DELETE /apps/:appName/envs
 	r.POST("/apps/:appName/envs/upload", envController.Upload)
+
+	r.POST("/apps/:appName/healthcheck", healthcheckController.Update)
 
 	r.Run()
 }

--- a/templates/app.tmpl
+++ b/templates/app.tmpl
@@ -8,6 +8,10 @@
      .monospace {
        font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
      }
+
+     .form-healthcheck > * {
+       margin-right: 5px;
+     }
     </style>
   </head>
   <body>
@@ -36,6 +40,7 @@
           {{ end }}
         </div>
       </div>
+
       <div class="panel panel-default">
         <div class="panel-heading">
           <h3 class="panel-title">Build-time variables</h3>
@@ -85,6 +90,7 @@
           {{ end }}
         </div>
       </div>
+
       <div class="panel panel-default">
         <div class="panel-heading">
           <h3 class="panel-title">Environment variables</h3>
@@ -145,6 +151,35 @@
           </form>
           {{ end }}
         </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Health Check</h3>
+        </div>
+        <form class="form-inline form-healthcheck" method="POST" action="/apps/{{ .app }}/healthcheck">
+          <div class="panel-body">
+            <div class="form-group">
+              <label for="healthcheckPathInput">Path</label>
+              <input type="text" class="form-control monospace" id="healthcheckPathInput" name="path" value="{{ .healthcheck.Path }}" placeholder="PATH">
+            </div>
+            <div class="form-group">
+              <label for="healthchecIntervalnput">Interval (seconds)</label>
+              <input type="number" class="form-control monospace" id="healthchecIntervalInput" name="interval" value="{{ .healthcheck.Interval }}">
+            </div>
+            <div class="form-group">
+              <label for="healthchecMaxTryInput">Maximum try count</label>
+              <input type="number" class="form-control monospace" id="healthchecMaxTryInput" name="maxTry" value="{{ .healthcheck.MaxTry }}">
+            </div>
+          </div>
+          <div class="panel-footer">
+            <div class="text-right">
+              <div class="form-group">
+                <button type="submit" class="btn btn-primary">Save</button>
+              </div>
+            </div>
+          </div>
+        </form>
       </div>
     </div>
 


### PR DESCRIPTION
## WHY

paus-gitreceive now do healthcheck before completing deploy (https://github.com/dtan4/paus-gitreceive/pull/50). We have to configure healthcheck parameter on dashboard.
## WHAT

Implement new model and endpoint for healthcheck. Add form to configure healthcheck in app page.
